### PR TITLE
coverity: fix the Overflowed return value in msr.c

### DIFF
--- a/msr.c
+++ b/msr.c
@@ -28,7 +28,7 @@
 /*
  *  This function reads from requested MSR address
  */
-uint64_t msr_reg_read(int cpu, unsigned int reg_offset, int print_enabled)
+int msr_reg_read(int cpu, unsigned int reg_offset, int print_enabled)
 {
 	char buf[128];
 	uint64_t temp = 0;

--- a/pnp_utils_inc.h
+++ b/pnp_utils_inc.h
@@ -54,7 +54,7 @@ int addr_range_dump(unsigned int target, unsigned int numOfWords);
 int reg_write(unsigned int target, unsigned int dataBitSize, unsigned int value);
 int reg_read(unsigned int target, unsigned int dataBitSize);
 
-uint64_t msr_reg_read(int cpu, unsigned int reg_offset, int print_enabled);
+int msr_reg_read(int cpu, unsigned int reg_offset, int print_enabled);
 int msr_reg_write(int cpu, unsigned int reg_offset, uint64_t value);
 
 int read_nc_port(int v, int port, int *ret_val);


### PR DESCRIPTION
coverity report the error:
Event return_overflow: "status", which might have overflowed, is returned from the function.
It's because msr_reg_read return u64 while the status return in process_args is int tpe.

Tests Done:
1. Build and boot
2. peeknpoke function works

Tracked-On: OAM-129214