### PR TITLE
coverity: fix the coverity issue in peeknpoke

### DIFF
--- a/i2c.c
+++ b/i2c.c
@@ -270,7 +270,7 @@ int block_read_i2c_device(char bus, int addr, int reg, int size, uint8_t array_s
 	}
 
 	if (size == SMBUS_BLOCK_DATA || size == I2C_SMBUS_BLOCK_DATA) {
-		num_values = array_size;
+		num_values = array_size - 1;
 		for (i = 1; i < num_values; i++)
 			printf("value read = 0x%x ret=0x%x\n", data.block[i], ret);
 	}

--- a/mem_dump.c
+++ b/mem_dump.c
@@ -93,6 +93,9 @@ int reg_write(unsigned int target, unsigned int dataBitSize, unsigned int value)
 		}
 	} else {
 		printf("Failed opening /dev/mem file\n");
+		if (fd != -1) {
+			close(fd); // Close the file descriptor if it's not -1
+		}
 		return -2;
 	}
 	virt_addr = map_base + (target & MAP_MASK);
@@ -144,6 +147,9 @@ int addr_range_dump(unsigned int target, unsigned int numOfWords)
 		}
 	} else {
 		printf("Failed opening /dev/mem file\n");
+		if (fd != -1) {
+			close(fd); // Close the file descriptor if it's not -1
+		}
 		return -2;
 	}
 	virt_addr = map_base + (target & MAP_MASK);

--- a/peeknpoke.c
+++ b/peeknpoke.c
@@ -44,6 +44,8 @@ static void usage(void)
 				"\t v to get the version for peeknpoke\n");
 }
 
+// Define a maximum allowed size to prevent excessive memory allocation
+#define I2C_SMBUS_BLOCK_MAX 32  /* As specified in SMBus standard */
 static int process_i2c_args(int argc, char **argv)
 {
 	unsigned int bus;
@@ -84,7 +86,7 @@ static int process_i2c_args(int argc, char **argv)
 					return status;
 				}
 				hexstring_to_int(argv[7], &array_size);
-				if (array_size <= 0) {
+				if (array_size == 0 || array_size > (I2C_SMBUS_BLOCK_MAX + 2)) {
 					printf("Please use the proper size to read\n");
 					status = -1;
 					return status;


### PR DESCRIPTION
1. add the close(fd) to fix the RESOURCE_LEAK issue
2. fix the insecure data handling in peeknpoke.c

Tests Done:
1. Build and boot
2. crashlog function works

Tracked-On: OAM-126085